### PR TITLE
[argon-125-3.cfg] fix localization

### DIFF
--- a/GameData/NearFuturePropulsion/Parts/Argon/argon-125/argon-125-3.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Argon/argon-125/argon-125-3.cfg
@@ -24,9 +24,9 @@ PART
 	cost = 4160
 	category = FuelTank
 	subcategory = 0
-	title = #LOC_NFPropulsion_argon-125-1_title
+	title = #LOC_NFPropulsion_argon-125-3_title
 	manufacturer = #LOC_NFPropulsion_manufacturer_argyle_title
-	description = #LOC_NFPropulsion_argon-125-1_description
+	description = #LOC_NFPropulsion_argon-125-3_description
 	attachRules = 1,1,1,1,0
 
 	mass = 0.190293333


### PR DESCRIPTION
Copy paste fail ;)

The localization strings here were for the `argon-125-1` part, rather than this one (`-3`).