### PR TITLE
Move 2.5m lithium tanks into more-appropriate CTT tech nodes

### DIFF
--- a/GameData/NearFuturePropulsion/Patches/NFPropulsionCommunityTechTree.cfg
+++ b/GameData/NearFuturePropulsion/Patches/NFPropulsionCommunityTechTree.cfg
@@ -179,11 +179,11 @@
 // Lithium Fuel
 @PART[lithium-25-1]:NEEDS[CommunityTechTree]:FOR[NearFuturePropulsion]
 {
-	@TechRequired = specializedFuelStorage
+	@TechRequired = specializedPlasmaGeneration
 }
 @PART[lithium-25-2]:NEEDS[CommunityTechTree]:FOR[NearFuturePropulsion]
 {
-	@TechRequired = specializedFuelStorage
+	@TechRequired = advEMSystems
 }
 @PART[lithium-25-3]:NEEDS[CommunityTechTree]:FOR[NearFuturePropulsion]
 {


### PR DESCRIPTION
Most of the lithium propellant tanks are in the plasma portion of the community tech tree, but the full-length and half-length 2.5m tanks were in "Specialized Fuel Storage", an unrelated node two tiers lower than "Advanced Plasma Propulsion" where the quarter-length 2.5m tank is, and one tier below even the 0.625m tanks.  It's weird to have the largest tanks at a lower tech level than all the smaller ones, so I've moved the half-length 2.5m tank into the same node as its quarter-length sibling, and the full-length one into the next node up from there.  (This matches their relative positions in the stock tech tree, and the relative positions of the 1.25m lithium tanks: the full-length is a tier above the quarter- and half-length.)

This means the two largest lithium tanks are now much higher in the tech tree (two tiers up for one of them, three tiers for the other), but it seems appropriate, and it shouldn't have much impact since the tanks are used only with the plasma engines provided by these same nodes.  (Plus, NF Construction has lithium as an option on the octo-girders at an even-lower tech level, so this change doesn't actually remove low-tech large-volume lithium storage.)